### PR TITLE
Fix MarksupSafe dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ click==6.7
 Flask==1.0.2
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 Werkzeug==0.14.1


### PR DESCRIPTION
This closes #1

Currently, setup.py is broken due to MarkupSafe 1.0. This fixes it.